### PR TITLE
fix compilation of cgrammar.c

### DIFF
--- a/src/cgrammar.y
+++ b/src/cgrammar.y
@@ -877,7 +877,7 @@ specClauseListExpr
 ;
 
 optSpecClauseList
- : /* empty */ { DPRINTF ((message("Empty optSpecClauseList") )); $$ = sRefSet_undefined }
+ : /* empty */ { DPRINTF ((message("Empty optSpecClauseList") )); $$ = sRefSet_undefined; }
  | specClauseList
  ;
 
@@ -963,10 +963,10 @@ sizeofExpr
    sizeofExprAux { context_sizeofReleaseVars (); $$ = $3; }
 ;
 
-processSizeof: {context_enterSizeof()};
+processSizeof: {context_enterSizeof();};
 
 
-endprocessSizeof: {context_leaveSizeof()};
+endprocessSizeof: {context_leaveSizeof();};
 
 
 sizeofExprAux 


### PR DESCRIPTION
I am getting the following errors when trying to compile:
gcc -DHAVE_CONFIG_H -I. -I..  -I./Headers -I.   -g -O2 -MT cgrammar.o -MD -MP -MF .deps/cgrammar.Tpo -c -o cgrammar.o cgrammar.c
cgrammar.c: In function âyyparseâ:
cgrammar.c:4651:90: error: expected â;â before â}â token
     { DPRINTF ((message("Empty optSpecClauseList") )); (yyval.srset) = sRefSet_undefined }
                                                                                          ^
cgrammar.c:4886:27: error: expected â;â before â}â token
     {context_enterSizeof()}
                           ^
cgrammar.c:4892:27: error: expected â;â before â}â token
     {context_leaveSizeof()}
                           ^
