### PR TITLE
Fix text of debug msg in context_exitInner

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -3302,7 +3302,7 @@ context_exitInner (exprNode exp)
 {
    if (context_getFlag (FLG_GRAMMAR))
     {
-      lldiagmsg (message ("Enter inner context: %q", context_unparse ()));
+      lldiagmsg (message ("Exit inner context: %q", context_unparse ()));
     }
  
   llassertprint (gc.inclause == NOCLAUSE || gc.inclause == CASECLAUSE,


### PR DESCRIPTION
The debug message written for the function _context_exitInner_ in _context.c_ contained a copy-paste error indicating the wrong function, which could be confusing during debug.