### PR TITLE
Removing type-conflicting definition of yyleng

### DIFF
--- a/src/Headers/globals.h
+++ b/src/Headers/globals.h
@@ -35,7 +35,6 @@ extern /*@owned@*/ fileloc g_currentloc;
 /*@-declundef@*/ /* Might not process grammar files */
 extern /*@dependent@*/ /*@open@*/ FILE *yyin;
 extern /*@dependent@*/ /*@open@*/ /*@unused@*/ FILE *yyout;
-extern /*@unused@*/ int yyleng;
 /*@=incondefs@*/ 
 
 extern int yydebug;


### PR DESCRIPTION
The definition of `yyleng` as `int` in Headers/globals.h (which was marked unused) causes a conflict with another definition of `yyleng` as `yy_len_t`. Removing the definition from globals.h fixes the conflict and allows the build to complete successfully.

```
Compiling cscanner.c...
In file included from Headers/basic.h:46,
                 from lex.yy.c:898:
Headers/globals.h:38: error: conflicting types for 'yyleng'
lex.yy.c:280: error: previous declaration of 'yyleng' was here
*** Error 1 in src (Makefile:1105 'cscanner.o': @echo "Compiling "cscanner.c"...";  source='cscanner.c' object='cscanner.o' libtool=no  depf...)
*** Error 1 in src (Makefile:1044 'Headers/flag_codes.gen')
*** Error 1 in . (Makefile:278 'all-recursive')
*** Error 1 in /home/peter/checkouts/splint (Makefile:195 'all')
```