### PR TITLE
Adding a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+Makefile
+*.o
+config.h
+config.log
+config.status
+src/.deps/
+src/Headers/flag_codes.gen
+src/cgrammar.c
+src/cscanner.c
+src/lex.yy.c
+src/llgrammar.c
+src/signature.c


### PR DESCRIPTION
I noticed when making another PR that there is no `.gitignore` file in the repository, so there are lots of untracked files hanging around in the repo after a build. I have added a basic one to keep dynamically generated files from being committed.

If anyone has feedback on my initial list, please do let me know, I'd be happy to update it as necessary before merge.

I also noticed that `test/Makefile` has already been committed to the repo -- should it be removed and added to `.gitignore` since it's generated by `configure`?