### PR TITLE
Treat array[1] as equivalent to pointer for purposes of -> operator

### DIFF
--- a/src/exprNode.c
+++ b/src/exprNode.c
@@ -4206,7 +4206,14 @@ exprNode_arrowAccessAux (/*@only@*/ exprNode s, /*@observer@*/ fileloc loc,
       
       checkMacroParen (s);
       
-      (void) ctype_fixArrayPtr (tr); /* REWRITE THIS */
+      /* CBS, 2014-03-25
+       * treat single-element arrays as equivalent to pointers
+       * (consider making this optional)
+       */
+      if (ctype_isFixedArray(tr) && ctype_getArraySize(tr) == 1)
+      {
+         tr = ctype_makePointer (ctype_baseArrayPtr (tr));
+      }
       
       if (ctype_isRealPointer (tr)) 
 	{


### PR DESCRIPTION
Hi, Glad to see splint has a home at last!

I've been using this tool in my work for a number of years and I've maintained a few fixes and improvements that I'll be offering to the community.

First is this one - to treat an array of length 1 as equivalent to a pointer for the purposes of checking validity of the -> operator.
