### PR TITLE
Remove leading space before comment in man page

### DIFF
--- a/doc/splint.1
+++ b/doc/splint.1
@@ -1,4 +1,4 @@
- .\" $Id: splint.1,v 1.2 2003/03/31 18:19:38 drl7x Exp $
+.\" $Id: splint.1,v 1.2 2003/03/31 18:19:38 drl7x Exp $
 .TH splint 1 "A tool for statically checking C programs"
 
 .SH NAME


### PR DESCRIPTION
There was a space before the comment on line 1 of the man page, which (at least on mandoc) causes the '.' to be displayed in the formatted output.