### PR TITLE
Support for c99-style 'for' predicate & minor autotools updates

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,8 @@
-AC_INIT([Splint], [3.1.2], [splint-bug@splint.org])
+AC_INIT([Splint],[3.1.2],[splint-bug@splint.org])
 dnl This MUST precede any other macro
 AC_CONFIG_AUX_DIR([config-aux])
 
-AC_CANONICAL_SYSTEM
+AC_CANONICAL_TARGET
 
 dnl Set up automake & the configuration header
 AM_INIT_AUTOMAKE([foreign])
@@ -26,7 +26,15 @@ AC_PROG_CC
 dnl Checks for header files.
 dnl Currently all disable, as the source files don't care about the results
 dnl AC_HEADER_DIRENT
-dnl AC_HEADER_STDC
+dnl m4_warn([obsolete],
+[The preprocessor macro `STDC_HEADERS' is obsolete.
+  Except in unusual embedded environments, you can safely include all
+  ISO C90 headers unconditionally.])dnl
+# Autoupdate added the next two lines to ensure that your configure
+# script's behavior did not change.  They are probably safe to remove.
+AC_CHECK_INCLUDES_DEFAULT
+AC_PROG_EGREP
+
 dnl AC_CHECK_HEADERS([alloca.h errno.h fcntl.h float.h limits.h locale.h malloc.h stddef.h stdlib.h string.h strings.h sys/time.h unistd.h])
 
 dnl Checks for typedefs, structures, and compiler characteristics.
@@ -39,8 +47,27 @@ dnl AC_TYPE_PID_T
 dnl AC_TYPE_SIZE_T
 dnl AC_STRUCT_ST_BLOCKS
 dnl AC_CHECK_MEMBERS([struct stat.st_rdev])
-dnl AC_DECL_SYS_SIGLIST
-dnl AC_HEADER_TIME
+dnl AC_CHECK_DECLS([sys_siglist],[],[],[#include <signal.h>
+/* NetBSD declares sys_siglist in unistd.h.  */
+#ifdef HAVE_UNISTD_H
+# include <unistd.h>
+#endif
+])
+
+dnl m4_warn([obsolete],
+[Update your code to rely only on HAVE_SYS_TIME_H,
+then remove this warning and the obsolete code below it.
+All current systems provide time.h; it need not be checked for.
+Not all systems provide sys/time.h, but those that do, all allow
+you to include it and time.h simultaneously.])dnl
+AC_CHECK_HEADERS_ONCE([sys/time.h])
+# Obsolete code to be removed.
+if test $ac_cv_header_sys_time_h = yes; then
+  AC_DEFINE([TIME_WITH_SYS_TIME],[1],[Define to 1 if you can safely include both <sys/time.h>
+	     and <time.h>.  This macro is obsolete.])
+fi
+# End of obsolete code.
+
 dnl AC_STRUCT_TM
 dnl AC_CHECK_TYPES([ptrdiff_t])
 
@@ -56,11 +83,23 @@ dnl AC_FUNC_MEMCMP
 dnl AC_FUNC_MKTIME
 dnl AC_FUNC_MMAP
 dnl AC_FUNC_SETVBUF_REVERSED
-dnl AC_TYPE_SIGNAL
+dnl m4_warn([obsolete],
+[your code may safely assume C89 semantics that RETSIGTYPE is void.
+Remove this warning and the `AC_CACHE_CHECK' when you adjust the code.])dnl
+AC_CACHE_CHECK([return type of signal handlers],[ac_cv_type_signal],[AC_COMPILE_IFELSE(
+[AC_LANG_PROGRAM([#include <sys/types.h>
+#include <signal.h>
+],
+		 [return *(signal (0, 0)) (0) == 1;])],
+		   [ac_cv_type_signal=int],
+		   [ac_cv_type_signal=void])])
+AC_DEFINE_UNQUOTED([RETSIGTYPE],[$ac_cv_type_signal],[Define as the return type of signal handlers
+		    (`int' or `void').])
+
 dnl AC_FUNC_STAT
 dnl AC_FUNC_STRCOLL
 dnl AC_FUNC_STRERROR_R
-dnl AC_FUNC_VFORK
+dnl AC_FUNC_FORK
 dnl AC_FUNC_VPRINTF
 dnl AC_FUNC_WAIT3
 dnl AC_CHECK_FUNCS([alarm atexit btowc bzero dup2 endgrent endpwent fchdir floor ftruncate getcwd getgroups gethostname gettimeofday isascii iswprint lchown localeconv mblen mbrlen mbrtowc memchr memmove memset mkdir mkfifo modf munmap pathconf pow putenv realpath regcomp rint rmdir rpmatch select setenv socket sqrt strcasecmp strchr strcspn strdup strerror strftime strncasecmp strpbrk strrchr strspn strstr strtod strtol strtoul strtoull tzset uname utime vprintf])
@@ -115,7 +154,7 @@ AC_DEFINE_UNQUOTED(LCL_COMPILE,
                    "Compiled using $CC $CFLAGS on `uname -a` by `whoami`",
                    [String describing who compiled this binary and how])
 
-dnl TODO: Use result AC_CANONICAL_SYSTEM to figure out what to define 
+dnl TODO: Use result AC_CANONICAL_TARGET to figure out what to define 
 
 AC_DEFINE(UNIX, 1, [Define if you're on a Unixy system])
 

--- a/src/cgrammar.y
+++ b/src/cgrammar.y
@@ -1095,7 +1095,7 @@ expr
 optExpr
  : /* empty */ { $$ = exprNode_undefined; }
  | expr 
- ;
+;
 
 constantExpr
  : conditionalExpr 
@@ -1747,6 +1747,15 @@ forPred
    TRPAREN 
    { $$ = exprNode_forPred ($3, $5, $8); 
      context_enterForClause ($5); }
+ | CFOR TLPAREN completeTypeSpecifier NotType namedDecl NotType TASSIGN 
+   { setProcessingVars ($3); processNamedDecl ($5); }
+   IsType init NotType TSEMI
+   { exprNode_makeInitialization ($5, $10); unsetProcessingVars (); }
+   optExpr TSEMI
+   { context_setProtectVars (); } optExpr { context_sizeofReleaseVars (); }
+   TRPAREN 
+   { $$ = exprNode_forPred (exprNode_undefined, $14, $17); 
+     context_enterForClause ($14); }
 ;
 
 partialIterStmt

--- a/src/cgrammar.y
+++ b/src/cgrammar.y
@@ -55,6 +55,7 @@ extern void yyerror (char *);
 # include "cscannerHelp.h"
 # include "cgrammar.h"
 # include "exprChecks.h"
+# include "cgrammar_tokens.h"
 
 /*@-allmacros@*/
 /*@-matchfields@*/

--- a/src/signature.y
+++ b/src/signature.y
@@ -56,7 +56,7 @@ static void yyprint (/*FILE *p_file, int p_type, YYSTYPE p_value */);
 
 %}
 
-%pure-parser 
+%define api.pure
 
 /* CONVENTIONS:  Reserved words are in ALL CAPS (plus markerSym)
 		Characters appearing in the grammar are reserved:


### PR DESCRIPTION
This kind of construct (c99-like) is now supported:

```c
  for(int foo = 0; foo < FOO_MAX; foo++)
    bar();
```

Now maybe my young co-workers will stop to give me shit & actually use the tool :)