### PR TITLE
Misc improvements

### DIFF
--- a/lib/unix.h
+++ b/lib/unix.h
@@ -2189,6 +2189,7 @@ int usleep (useconds_t useconds) /*@modifies systemState, errno@*/
      /*@ensures maxSet(result) <= 15 /\ maxRead(result) <= 15 @*/
      ;
 
+     extern int inet_aton(const char *cp, /*@out@*/ struct in_addr *inp) /*@modifies errno@*/ ;
 
      extern  double hypot(double x, double y) /*@modifies errno@*/ /*error errno only*/;
 

--- a/src/exprNode.c
+++ b/src/exprNode.c
@@ -1687,6 +1687,18 @@ checkPrintfArgs (/*@notnull@*/ /*@dependent@*/ exprNode f, uentry fcn,
 			  
 			  /*@switchbreak@*/ break;
 
+			case 'z': /* size_t & ssize_t */
+			  key = *code++;
+			  if(key == 'd')
+			    expecttype = ctype_signedintegral;
+			  else if(key == 'u')
+			    expecttype = ctype_unsignedintegral;
+			  else
+			    /* error */
+			    llfatalerrorLoc(message ("Bad character set format for %%z: %s",
+						     cstring_fromChars (origcode)));
+
+			  /*@switchbreak@*/ break;
 			  
 			default:
 			  expecttype = ctype_unknown;


### PR DESCRIPTION
This patch adds support for formats like %zd & %zu in printf-like functions, simplifies the grammar for c99-style loops & adds inet_aton() prototype to unix header file.
