### PR TITLE
Found in a large embedded project with a large legacy.

### DIFF
--- a/src/uentryList.c
+++ b/src/uentryList.c
@@ -753,7 +753,7 @@ uentryList_lookupField (uentryList f, cstring name)
 	{
 	  uentry old = uentryList_lookupField (f1, uentry_rawName (current));
 	  
-	  if (uentry_isValid (old))
+	  if (uentry_isValid (old) && uentry_rawName(current))
 	    {
 	      voptgenerror
 		(FLG_SYNTAX,

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -52,7 +52,7 @@ UNITTESTS = \
   special stack staticarray strings \
   stringliteral \
   structassign typequals typeof ud ulstypes union unioninit \
-  unnamedsu unreachable unsignedcompare \
+  unnamedsu unnamedreused unreachable unsignedcompare \
   unused ullint utypes void widestrings
 UNITEXPECTS = $(addsuffix .expect, $(UNITTESTS))
 
@@ -886,6 +886,10 @@ unioninit:
 unnamedsu:
 	-$(SPLINTR) unnamedsu.c -expect 0
 
+.PHONY: unnamedreused
+unnamedreused:
+	-$(SPLINTR) unnamedreused.c -expect 0
+
 .PHONY: unreachable
 unreachable:
 	-$(SPLINTR) unreachable.c -expect 5
@@ -1228,6 +1232,7 @@ EXTRA_DIST =  ./abst_t.lcl \
               ./unreachable.c \
               ./unsignedcompare.c \
               ./unnamedsu.c \
+              ./unnamedreused.c \
               ./unused.c \
               ./void.c \
               ./conditions/miroslaw.c \
@@ -1498,6 +1503,7 @@ EXTRA_DIST =  ./abst_t.lcl \
               ulstypes.expect \
               union.expect \
               unnamedsu.expect \
+              unnamedreused.expect \
               unreachable.expect \
               unsignedcompare.expect \
               unused.expect \

--- a/test/unnamedreused.c
+++ b/test/unnamedreused.c
@@ -1,0 +1,38 @@
+typedef struct
+{
+  union
+  {
+    int DWord;
+    struct
+    {
+      union
+      {
+        short WordL;
+        struct
+        {
+           unsigned char CharLL;
+           unsigned char CharLH;
+        };
+      };
+      union
+      {
+        short WordH;
+        struct
+        {
+           unsigned char CharHL;
+           unsigned char CharHH;
+        };
+      };
+    };
+  };
+} su;
+
+unsigned char f (int value)
+{
+  su This;
+
+  This.CharHH = (unsigned char)0;
+  This.DWord = value;
+  return This.CharHH;
+}
+

--- a/test/unnamedreused.expect
+++ b/test/unnamedreused.expect
@@ -1,0 +1,2 @@
+
+Finished checking --- no warnings


### PR DESCRIPTION
 Unnamed struct/union was giving a false warning (it's OK with gcc).
- Solution is to not generate a warning when the name is not set
- Test case added.
