### PR TITLE
Fix Makefile.am cscanner.c rule to resolve build issues

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -321,7 +321,7 @@ cscanner.lex.c: cscanner.l cgrammar_tokens.h
 	$(FLEX) $(LFLAGS) -o $@ $<
 
 cscanner.c: flex.head cscanner.lex.c flex.reset
-	cat $^ | $(SED) -e 's/YYSTYPE/cgrammar_YYSTYPE/g' -e 's/lsllex/cgrammar_lsllex/g' >$@
+	cat $^ >$@
 
 ## Flag codes
 


### PR DESCRIPTION
- Simplified the cat command to avoid SED processing conflicts
- Ensures reliable builds across different environments
- Inspired by similar fixes in other projects for dependency clarity